### PR TITLE
Top nav link hover colors now don't apply in dropdowns.

### DIFF
--- a/portal/static/css/style.css
+++ b/portal/static/css/style.css
@@ -114,7 +114,7 @@ nav a {
   background: #466BB0 linear-gradient(to right, #466BB0, #286AC7) no-repeat center/cover;
 }
 
-#topnav a:hover {
+#topnav a:not(.dropdown-item):hover {
   color: #c4c4c4;
 }
 


### PR DESCRIPTION
See #142 for more details.